### PR TITLE
Implement read and parse JSON structured secrets from AWS secretsmanager 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ The plugin uses the AWS Java SDK to communicate with Secrets Manager. If you are
 ## Usage
 
 Create the relevant secret in Secrets Manager. There are many ways to do this, including using Terraform or the AWS CLI. Then put the secret into your JCasC definition.
-`aws:secretsmanager:` is ued as a prefix so that the CasC plugin knows how to decode it. 
+Use the Secret-ARN to reference the secret.
+
 
 ### If the secret is plain text:
+
 #### Create Secret:
 ```bash
 aws secretsmanager create-secret --name 'my-secret' --secret-string 'abc123' --description 'Jenkins user password'
@@ -60,7 +62,7 @@ jenkins:
       allowsSignup: false
       users:
       - id: "some_user"
-        password: "${aws-secretsmanager:my-secret}"
+        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret}"
 ```
 
 ### If the secret value is key-value pairs (JSON)
@@ -70,8 +72,7 @@ aws secretsmanager create-secret --name 'my-json-secret' --secret-string '{"user
 ```
 
 #### JCasC definition:
-
-The `:` character is used as a delimiter between secret name and json key in the object. It is used as it is a forbidden character in a AWS Secretsmanager secret name and does not create trouble for Jenkins secrets management internally.
+Use the Secret-ARN and the json key in the secret to reference the value injected like: `${secret-arn:json-key}`
 
 ```yaml
 jenkins:
@@ -79,8 +80,26 @@ jenkins:
     local:
       allowsSignup: false
       users:
-      - id: "${aws-secretsmanager:my-json-secret:username}"
-        password: "${aws-secretsmanager:my-json-secret:password}"
+      - id: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:username}"
+        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:password}"
+```
+
+#### Deprecated - Reference Plain Text Secret via Secret Name
+
+#### Create Secret:
+```bash
+aws secretsmanager create-secret --name 'my-secret' --secret-string 'abc123' --description 'Jenkins user password'
+```
+
+#### JCasC definition:
+```yaml
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+      - id: "some_user"
+        password: "${my-secret}"
 ```
 
 Then start Jenkins.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The plugin uses the AWS Java SDK to communicate with Secrets Manager. If you are
 ## Usage
 
 Create the relevant secret in Secrets Manager. There are many ways to do this, including using Terraform or the AWS CLI. Then put the secret into your JCasC definition.
+`aws:secretsmanager:` is ued as a prefix so that the CasC plugin knows how to decode it. 
 
 ### If the secret is plain text:
 #### Create Secret:
@@ -59,7 +60,7 @@ jenkins:
       allowsSignup: false
       users:
       - id: "some_user"
-        password: "${my-secret}"
+        password: "${aws-secretsmanager:my-secret}"
 ```
 
 ### If the secret value is key-value pairs (JSON)
@@ -70,7 +71,7 @@ aws secretsmanager create-secret --name 'my-json-secret' --secret-string '{"user
 
 #### JCasC definition:
 
-The `>` character is used as a delimiter between secret name and json key in the object. It is used as it is a forbidden character in a AWS Secretsmanager secret name and does not create trouble for Jenkins secrets management internally.
+The `:` character is used as a delimiter between secret name and json key in the object. It is used as it is a forbidden character in a AWS Secretsmanager secret name and does not create trouble for Jenkins secrets management internally.
 
 ```yaml
 jenkins:
@@ -78,8 +79,8 @@ jenkins:
     local:
       allowsSignup: false
       users:
-      - id: "${my-json-secret>username}"
-        password: "${my-json-secret>password}"
+      - id: "${aws-secretsmanager:my-json-secret:username}"
+        password: "${aws-secretsmanager:my-json-secret:password}"
 ```
 
 Then start Jenkins.

--- a/README.md
+++ b/README.md
@@ -46,52 +46,16 @@ The plugin uses the AWS Java SDK to communicate with Secrets Manager. If you are
 Create the relevant secret in Secrets Manager. There are many ways to do this, including using Terraform or the AWS CLI. Then put the secret into your JCasC definition.
 Use the Secret-ARN to reference the secret.
 
+### Plain text secrets
 
-### If the secret is plain text:
+Create secret:
 
-#### Create Secret:
 ```bash
 aws secretsmanager create-secret --name 'my-secret' --secret-string 'abc123' --description 'Jenkins user password'
 ```
 
-#### JCasC definition:
-```yaml
-jenkins:
-  securityRealm:
-    local:
-      allowsSignup: false
-      users:
-      - id: "some_user"
-        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret}"
-```
+Reference it by name:
 
-### If the secret value is key-value pairs (JSON)
-#### Create Secret:
-```bash
-aws secretsmanager create-secret --name 'my-json-secret' --secret-string '{"username": "some_user", "password": "abc123" }' --description 'Jenkins user password'
-```
-
-#### JCasC definition:
-Use the Secret-ARN and the json key in the secret to reference the value injected like: `${secret-arn:json-key}`
-
-```yaml
-jenkins:
-  securityRealm:
-    local:
-      allowsSignup: false
-      users:
-      - id: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:username}"
-        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:password}"
-```
-
-#### Deprecated - Reference Plain Text Secret via Secret Name
-
-#### Create Secret:
-```bash
-aws secretsmanager create-secret --name 'my-secret' --secret-string 'abc123' --description 'Jenkins user password'
-```
-
-#### JCasC definition:
 ```yaml
 jenkins:
   securityRealm:
@@ -102,7 +66,37 @@ jenkins:
         password: "${my-secret}"
 ```
 
-Then start Jenkins.
+Or reference it by ARN:
+
+```yaml
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+      - id: "some_user"
+        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret}"
+```
+
+### JSON secrets
+
+Create secret:
+
+```bash
+aws secretsmanager create-secret --name 'my-secret' --secret-string '{"username": "some_user", "password": "abc123" }' --description 'Jenkins user password'
+```
+
+Reference it by ARN and JSON key:
+
+```yaml
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+      - id: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:username}"
+        password: "${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret:password}"
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,34 @@ The plugin uses the AWS Java SDK to communicate with Secrets Manager. If you are
 
 ## Usage
 
-Create the relevant secret in Secrets Manager. There are many ways to do this, including using Terraform or the AWS CLI:
+Create the relevant secret in Secrets Manager. There are many ways to do this, including using Terraform or the AWS CLI. Then put the secret into your JCasC definition.
 
+### If the secret is plain text:
+#### Create Secret:
 ```bash
-aws secretsmanager create-secret --name 'my-password' --secret-string 'abc123' --description 'Jenkins user password'
+aws secretsmanager create-secret --name 'my-secret' --secret-string 'abc123' --description 'Jenkins user password'
 ```
 
-Then put the secret's name in your JCasC definition:
+#### JCasC definition:
+```yaml
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+      - id: "some_user"
+        password: "${my-secret}"
+```
+
+### If the secret value is key-value pairs (JSON)
+#### Create Secret:
+```bash
+aws secretsmanager create-secret --name 'my-json-secret' --secret-string '{"username": "some_user", "password": "abc123" }' --description 'Jenkins user password'
+```
+
+#### JCasC definition:
+
+The `>` character is used as a delimiter between secret name and json key in the object. It is used as it is a forbidden character in a AWS Secretsmanager secret name and does not create trouble for Jenkins secrets management internally.
 
 ```yaml
 jenkins:
@@ -57,8 +78,8 @@ jenkins:
     local:
       allowsSignup: false
       users:
-      - id: "foo"
-        password: "${my-password}"
+      - id: "${my-json-secret>username}"
+        password: "${my-json-secret>password}"
 ```
 
 Then start Jenkins.

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.2</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.22.0</version>

--- a/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
@@ -38,7 +38,7 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
             final String jsonKey;
             final Arn secretArn;
 
-            if(id.startsWith(ARN_PREFIX)) {
+            if (id.startsWith(ARN_PREFIX)) {
                 secretArn = Arn.fromString(id);
                 secretId = secretArn.getResource().getResource();
                 jsonKey = secretArn.getResource().getQualifier();
@@ -47,8 +47,9 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
                 jsonKey = null;
             }
 
-            final GetSecretValueResult result = client.getSecretValue(
-                new GetSecretValueRequest().withSecretId(secretId));
+            final GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(secretId);
+
+            final GetSecretValueResult result = client.getSecretValue(request);
 
             if (result.getSecretBinary() != null) {
                 throw new IOException(String.format("The binary secret '%s' is not supported. Please change its value to a string, or alternatively delete it.", result.getName()));
@@ -56,7 +57,6 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
 
             final String resultString = result.getSecretString();
 
-            // The secret id and a json key inside the object are defined.
             // Secret is expected to be a json object.
             if (secretId != null && jsonKey != null) {
                 ObjectMapper mapper = new ObjectMapper();
@@ -64,7 +64,6 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
                 Map<String, String> map = mapper.readValue(resultString, typeRef);
                 return Optional.ofNullable(map.get(jsonKey));
             } else {
-                // Only secret name is specified.
                 // The secret is expected to be a plain string.
                 return Optional.ofNullable(resultString);
             }

--- a/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
@@ -9,10 +9,12 @@ import com.amazonaws.services.secretsmanager.model.AWSSecretsManagerException;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.Extension;
 import io.jenkins.plugins.casc.SecretSource;
-
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -24,24 +26,49 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
 
     private static final String AWS_SERVICE_ENDPOINT = "AWS_SERVICE_ENDPOINT";
     private static final String AWS_SIGNING_REGION = "AWS_SIGNING_REGION";
+    private static final String AWS_SECRET_NAME_SPLIT_CHARACTER = ">";
 
     private transient AWSSecretsManager client = null;
 
     @Override
     public Optional<String> reveal(String id) throws IOException {
         try {
-            final GetSecretValueResult result = client.getSecretValue(new GetSecretValueRequest().withSecretId(id));
+            String secretName = id;
+            String jsonKey = null;
+
+            // Split id into secret name and json object key if a ">" exists.
+            if(id.contains(AWS_SECRET_NAME_SPLIT_CHARACTER)) {
+                String[] secretNameAndJsonKey = id.split(AWS_SECRET_NAME_SPLIT_CHARACTER);
+                secretName = secretNameAndJsonKey[0];
+                jsonKey = secretNameAndJsonKey[1];
+            }
+
+            final GetSecretValueResult result = client.getSecretValue(
+                new GetSecretValueRequest().withSecretId(secretName));
 
             if (result.getSecretBinary() != null) {
                 throw new IOException(String.format("The binary secret '%s' is not supported. Please change its value to a string, or alternatively delete it.", result.getName()));
             }
 
-            return Optional.ofNullable(result.getSecretString());
+            String resultString = result.getSecretString();
+
+            // The secret name and a key inside the json object are defined.
+            // Secret is expected to be a json object.
+            if (secretName != null && jsonKey != null) {
+                ObjectMapper mapper = new ObjectMapper();
+                TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
+                Map<String, String> map = mapper.readValue(resultString, typeRef);
+                return Optional.ofNullable(map.get(jsonKey));
+            } else {
+                // Only secret name is specified.
+                // The secret is expected to be a plain string.
+                return Optional.ofNullable(resultString);
+            }
         } catch (ResourceNotFoundException e) {
             // Recoverable errors
             LOG.info(e.getMessage());
             return Optional.empty();
-        } catch (AWSSecretsManagerException e) {
+        } catch (AWSSecretsManagerException | ArrayIndexOutOfBoundsException e) {
             // Unrecoverable errors
             LOG.warning(e.getMessage());
             throw new IOException(e);

--- a/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
+++ b/src/main/java/io/jenkins/plugins/casc/secretsmanager/AwsSecretsManagerSecretSource.java
@@ -26,7 +26,7 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
 
     private static final String AWS_SERVICE_ENDPOINT = "AWS_SERVICE_ENDPOINT";
     private static final String AWS_SIGNING_REGION = "AWS_SIGNING_REGION";
-    private static final String AWS_SECRET_NAME_SPLIT_CHARACTER = ">";
+    private static final String AWS_SECRET_NAME_SPLIT_CHARACTER = ":";
 
     private transient AWSSecretsManager client = null;
 
@@ -36,7 +36,7 @@ public class AwsSecretsManagerSecretSource extends SecretSource {
             String secretName = id;
             String jsonKey = null;
 
-            // Split id into secret name and json object key if a ">" exists.
+            // Split id into secret name and json object key if a ":" exists.
             if(id.contains(AWS_SECRET_NAME_SPLIT_CHARACTER)) {
                 String[] secretNameAndJsonKey = id.split(AWS_SECRET_NAME_SPLIT_CHARACTER);
                 secretName = secretNameAndJsonKey[0];

--- a/src/test/java/io/jenkins/plugins/casc/secretsmanager/SecretSourceIT.java
+++ b/src/test/java/io/jenkins/plugins/casc/secretsmanager/SecretSourceIT.java
@@ -24,8 +24,8 @@ public class SecretSourceIT {
     private static final String STRING_SECRET_VALUE = "supersecret";
     private static final byte[] BINARY_SECRET_VALUE = {0x01, 0x02, 0x03};
     private static final String JSON_SECRET_NAME = "secretName";
-    private static final String JSON_SECRET_NAME_AND_KEY = "secretName>someKey";
-    private static final String JSON_SECRET_NAME_KEY_AND_BROKEN = "secretName>";
+    private static final String JSON_SECRET_NAME_AND_KEY = "AWSSecretsmanager:secretName:someKey";
+    private static final String JSON_SECRET_NAME_KEY_AND_BROKEN = "AWSSecretsmanager:secretName:";
     private static final String JSON_SECRET_VALUE = "{\"someKey\": \"someSecretValue\"}";
     private static final String JSON_SECRET_VALUE_BROKEN = "{Some broken Json []}";
 
@@ -148,5 +148,6 @@ public class SecretSourceIT {
 
     private String revealSecret(String id) {
         return context.getSecretSourceResolver().resolve("${" + id + "}");
+
     }
 }


### PR DESCRIPTION
Hey,

I used your Jenkins plugin to get secrets from AWS into Jenkins. It was really helpful but I felt it would be useful if it was possible to also use secrets that contain key value pairs and are therefor stored in a json structure.

- Implemented functionality to read JSON structured secrets.
  -  To use a secret the secret name and the json key in the object need to be provided like `secretName>jsonKey`
- `>` is used as a delimiter as `.` or `:` did not work. (see below)
- The functionality is explained in the README.md. 
- Tests are implemented.


I had rather used `.` or `:` as a delimiter instead of `>` but `.` is an available character in a secret name and `:` is filtered out internally by Jenkins for some reason. If you have another preference please let me know.

I would really like to hear your feedback on it. If you like it please merge it so that others can profit from it as well.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
