### PR TITLE
Fix: Update Moto image construction in tests

### DIFF
--- a/src/test/java/io/jenkins/plugins/casc/secretsmanager/util/AWSSecretsManagerRule.java
+++ b/src/test/java/io/jenkins/plugins/casc/secretsmanager/util/AWSSecretsManagerRule.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Wraps client-side access to AWS Secrets Manager in tests. Defers client initialization in case you want to set AWS
@@ -14,17 +14,12 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
  */
 public class AWSSecretsManagerRule extends ExternalResource {
 
-    private static final ImageFromDockerfile MOTO_IMAGE = new ImageFromDockerfile()
-                .withDockerfileFromBuilder(b ->
-                        b.from("python:3.7")
-                                .run("pip install moto[server]==2.3.0")
-                                .cmd("moto_server -H 0.0.0.0 -p 4584")
-                                .build());
+    private static final DockerImageName MOTO_IMAGE = DockerImageName.parse("motoserver/moto:2.3.0");
 
     private static final String SIGNING_REGION = "us-east-1";
 
     private final GenericContainer<?> secretsManager = new GenericContainer<>(MOTO_IMAGE)
-            .withExposedPorts(4584)
+            .withExposedPorts(5000)
             .waitingFor(Wait.forHttp("/"));
 
     private transient AWSSecretsManager client;


### PR DESCRIPTION
Update Moto image construction in tests to the new `motoserver` image, so they don't fail.