### PR TITLE
Remove joda-time dependency version pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,6 @@
         </dependency>
         <dependency>
             <!-- Workaround -->
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10.14</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- Workaround -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>


### PR DESCRIPTION
Remove the version pin for `joda-time` since it is apparently no longer needed