### PR TITLE
[chore] Remove workaround dependency version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,3 @@ In your IDE:
 3. Start Moto: `mvn docker:build docker:start`.
 4. Run tests.
 5. Stop Moto: `mvn docker:stop`.
-
-### Notes
-
-The dependencies marked `<!-- Workaround -->` in the POM have only been added to satisfy Maven dependency version constraints. This plugin does not directly use those dependencies.

--- a/pom.xml
+++ b/pom.xml
@@ -85,20 +85,6 @@
             <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <!-- Workaround -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- Workaround -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Now that we have CD automated releases and Dependabot, we don't need to pin the versions of auxiliary dependencies.

