### PR TITLE
[fix] Change the project SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <scm>
         <connection>https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
-        <url>https://github.com/${gitHubRepo}/blob/main/README.md</url>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
 


### PR DESCRIPTION
This fix the URL of the SCM. 
This url is used by the update-center to point to the plugin repository, which is used by the plugins.jenkins.io web-site. 

The documentation URL is based on the `project.url` not the `project.scm.url`. And there is no requirement to point specifically to the README.md file as it's in a "default" location for GitHub. See https://www.jenkins.io/doc/developer/publishing/documentation. 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
