### PR TITLE
Use aws-java-sdk-secretsmanager dependency from BOM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def recentLTS = "2.361.1"
+def recentLTS = "2.387.1"
 def configurations = [
     [ platform: "linux", jdk: "11", jenkins: null ],
     [ platform: "linux", jdk: "11", jenkins: recentLTS ],

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.1</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -50,8 +50,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1792.v0295db_e7c548</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2357.v1043f8578392</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -64,9 +64,8 @@
             <artifactId>configuration-as-code</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.12.287-357.vf82d85a_6eefd</version>
+            <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+            <artifactId>aws-java-sdk-secretsmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>


### PR DESCRIPTION
Use the `aws-java-sdk-secretsmanager` dependency from the Jenkins BOM.

Not only does this reduce the footprint of the SDK dependency compared to before, it also means that version updates are handled by the BOM instead.

This change requires a minimum Jenkins version of 2.387.x

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
